### PR TITLE
Fix the type of condition

### DIFF
--- a/boo
+++ b/boo
@@ -12,7 +12,7 @@ function get_boo_root_path {
     local npm_root="$(npm config get prefix)/lib/node_modules/boo"
     local yarn_root="$(yarn global dir)/node_modules/boo"
     
-    if [ -f "${npm_root}" ]; then
+    if [ -d "${npm_root}" ]; then
       boo_root_path="${npm_root}"
     else
       boo_root_path="${yarn_root}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boo",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Meteor Deployment Toolkit",
   "main": "boo.sh",
   "bin": {


### PR DESCRIPTION
The problem occurs after installing the latest version of `boo`.
It ignores the `npm` package and tries to use a yarn package

```
/Users/vadym/.nvm/versions/node/v8.8.1/bin/boo: line 62: /Users/vadym/.config/yarn/global/node_modules/boo/common.sh: No such file or directory
/Users/vadym/.nvm/versions/node/v8.8.1/bin/boo: line 36: source_config_file: command not found
/Users/vadym/.nvm/versions/node/v8.8.1/bin/boo: line 48: ensure_meteor_root_dir: command not found
/Users/vadym/.nvm/versions/node/v8.8.1/bin/boo: line 53: echo_error: command not found
```